### PR TITLE
github actions를 통한 ci 추가

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
   push: 
     branches: 
       - main
+    paths:
+      - 'src/**'
 
 jobs:
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,38 @@
+name: CI
+
+on: 
+  push: 
+    branches: 
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Setup Pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.16.1
+          cache: 'pnpm'
+      
+      - name: Cache Dependencies
+        id: cache
+        uses: actions/cache@v3
+        with: 
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml')}}
+          restore-keys: ${{ runner.os }}-node-
+
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pnpm install
+
+      - name: Execute Test
+        run: pnpm test


### PR DESCRIPTION
## ✨ 구현한 내용
- github actions를 통한 ci를 구축합니다.
  - main에 push 이벤트가 발생할 경우 test를 실행합니다.
  - Node Version: 18.16.1
  - 패키지 매니저 pnpm 사용, pnpm version: 8
  - dependencies 설치 시 Cache 적용
    - 참고한 내용: [뱅크샐러드 기술블로그](https://blog.banksalad.com/tech/github-action-npm-cache/)

## 📑 논의사항
1. 테스트가 추가되거나 변경되었을 때 ci를 실행할 것을 제안해주셨는데, 이 경우에는 main에 push되는 것이 아니라 pr이 생성되는 시점을 말씀하신 걸까요? main에 push되는 경우라면 test 파일의 변경 여부와 관계 없이 ci가 실행될 것이라고 판단하여 별도의 이벤트를 감지하지 않아도 될 거라고 생각이 되어서요.

2. 테스트 관련 파일은 다음과 같이 관리하면 좋을 것이라 생각했습니다.
    - `src/components/common/Button`처럼 별도의 디렉토리에서 관련 파일을 함께 관리하는 경우 해당 디렉토리 내부에 *.test.ts 파일을 생성합니다.
    - pages 파일처럼 별도의 디렉토리가 없는 경우 `src/pages` 내에 __test__ 디렉토리를 생성하고 해당 디렉토리 내부에 *.test.ts 파일을 생성합니다.
위 방법이 통일성을 해치거나 제가 생각하지 못한 문제를 동반한다면 말씀해주시면 감사하겠습니다!

혹은 제가 놓친 부분이 있다면 말씀해주세요!