### PR TITLE
QR인증 임시 페이지 추가

### DIFF
--- a/src/pages/registration/[id].tsx
+++ b/src/pages/registration/[id].tsx
@@ -1,0 +1,14 @@
+import { useRouter } from 'next/router';
+
+export default function RegistrationId() {
+  const router = useRouter();
+
+  return (
+    <>
+      <main>
+        <p>Hello my id is {router.query.id}</p>
+        <p>Type is {router.query.type}</p>
+      </main>
+    </>
+  );
+}

--- a/src/pages/registration/index.tsx
+++ b/src/pages/registration/index.tsx
@@ -1,0 +1,41 @@
+import { useRouter } from 'next/router';
+import { useState, useEffect } from 'react';
+
+import QRCodeCanvas from '@/components/common/QRCodeCanvas';
+
+export default function Registration() {
+  const router = useRouter();
+
+  const [ogUrl, setOgUrl] = useState('');
+  const [value, setValue] = useState('');
+  const [valueType, setValueType] = useState<'S' | 'B' | 'D'>();
+
+  useEffect(() => {
+    const host = window.location.host;
+    const baseUrl = `https://${host}`;
+
+    setOgUrl(`${baseUrl}${router.pathname}/${value}?type=${valueType}`);
+  }, [router.pathname, value, valueType]);
+
+  return (
+    <>
+      <main>
+        <input
+          type="text"
+          value={value}
+          onChange={e => setValue(e.target.value)}
+        />
+        <select
+          value={valueType}
+          onChange={e => setValueType(e.target.value as 'S' | 'B' | 'D')}
+        >
+          <option value="S">Squat</option>
+          <option value="B">Bench press</option>
+          <option value="D">Deadlift</option>
+        </select>
+
+        <QRCodeCanvas url={`${ogUrl}/`} />
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
# 설명
- `/registration`에서 QR 코드를 생성 후 이동을 하면 `/registration/[id]?type={type}`으로 이동합니다.

# 테스트
- [ ] `/registration`에서 QR 코드를 생성 후 이동을 하면 적절한 URL으로 이동하는지 확인합니다.