### PR TITLE
[ADD] TextField 컴포넌트 추가

### DIFF
--- a/src/components/signup/SignupForm/TextField/index.stories.tsx
+++ b/src/components/signup/SignupForm/TextField/index.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { useState } from 'react';
+
+import Button from '@/components/common/Button';
+
+import TextField from '.';
+
+const meta: Meta<typeof TextField> = {
+  component: TextField,
+};
+
+export default meta;
+
+type Story = StoryFn<typeof TextField>;
+
+export const Default: Story = () => {
+  const [value, setValue] = useState('테스트');
+
+  return <TextField value={value} onChange={e => setValue(e.target.value)} />;
+};
+
+export const TextFieldWithButton: Story = () => {
+  const [value, setValue] = useState('테스트');
+
+  return (
+    <TextField
+      value={value}
+      onChange={e => setValue(e.target.value)}
+      sideContent={<Button>중복 확인</Button>}
+    />
+  );
+};
+
+export const TextFieldWithUnit: Story = () => {
+  const [value, setValue] = useState('테스트');
+
+  return (
+    <TextField
+      value={value}
+      onChange={e => setValue(e.target.value)}
+      sideContent={<span style={{ color: '#CACACA' }}>CM</span>}
+    />
+  );
+};

--- a/src/components/signup/SignupForm/TextField/index.tsx
+++ b/src/components/signup/SignupForm/TextField/index.tsx
@@ -1,0 +1,13 @@
+import { TextFieldProps } from './type';
+import * as S from './style';
+
+const TextField = ({ sideContent, ...props }: TextFieldProps) => {
+  return (
+    <S.TextFieldWrapper>
+      <S.TextField {...props} />
+      <S.SideContent>{sideContent != null ? sideContent : null}</S.SideContent>
+    </S.TextFieldWrapper>
+  );
+};
+
+export default TextField;

--- a/src/components/signup/SignupForm/TextField/style.ts
+++ b/src/components/signup/SignupForm/TextField/style.ts
@@ -1,0 +1,34 @@
+import { styled } from '@/styles/stitches.config';
+
+export const TextFieldWrapper = styled('div', {
+  position: 'relative',
+
+  width: '100%',
+});
+
+export const TextField = styled('input', {
+  width: '100%',
+
+  padding: '16px',
+
+  borderRadius: '4px',
+  backgroundColor: '#5C5C5C',
+
+  '&[type="number"]::-webkit-outer-spin-button, &[type="number"]::-webkit-inner-spin-button':
+    {
+      WebkitAppearance: 'none',
+      margin: 0,
+    },
+
+  '&::placeholder': {
+    color: '#CACACA',
+  },
+});
+
+export const SideContent = styled('div', {
+  position: 'absolute',
+  right: '12px',
+  top: '50%',
+
+  transform: 'translateY(-50%)',
+});

--- a/src/components/signup/SignupForm/TextField/type.ts
+++ b/src/components/signup/SignupForm/TextField/type.ts
@@ -1,0 +1,8 @@
+import { ComponentProps, ReactElement } from 'react';
+
+import { TextField } from './style';
+
+export interface TextFieldProps extends ComponentProps<typeof TextField> {
+  error?: boolean;
+  sideContent?: ReactElement;
+}


### PR DESCRIPTION
## ✨ 구현한 내용

- TextField 컴포넌트를 추가합니다.
- 필요에 따라 sideContent props를 통해 컴포넌트를 렌더링할 수 있습니다.

## ❓ 특이사항

- 입력값이 유효한지에 대해 error props로 넘겨 받고, 이를 부모 컴포넌트에서 확인할 수 있도록 구현하였습니다(Select 컴포넌트도 마찬가지). 그런데 error props가 실제 DOM에 없는 속성이라 이를 별도로 빼내야 할 것 같은데, 그렇게 하면 사용하지 않는 변수가 있다고 eslint가 알려줘서 적절한 해결방법이 무엇인지 조금 더 고민해봐야 할 것 같습니다.
- error props를 FormRow에서 관리하지 않고 TextField 및 Select에서 관리하는 이유는 각 컴포넌트가 error 상태인지 아닌지 스스로가 알고 있어야 한다고 생각해서입니다.

```tsx
// error props를 별도로 빼는 경우 eslint error가 발생
const TextField = ({ error, sideContent, ...props }: TextFieldProps) => {
  return (
    <S.TextFieldWrapper>
      <S.TextField {...props} />
      <S.SideContent>{sideContent != null ? sideContent : null}</S.SideContent>
    </S.TextFieldWrapper>
  );
};
```

- 디자이너와 이야기 해서 error 시 글자색을 빨갛게 표시하는 것도 해결 방법이 될 수 있을 것 같습니다.

## 🧾 테스트 방법
- 스토리북을 통해 테스트할 수 있습니다.