### PR TITLE
[ADD] Select 컴포넌트 추가

### DIFF
--- a/src/components/common/Icon/Icons/ArrowDownIcon.tsx
+++ b/src/components/common/Icon/Icons/ArrowDownIcon.tsx
@@ -1,0 +1,33 @@
+import { SVGProps } from 'react';
+
+function ArrowDownIcon({
+  width = 24,
+  height = 24,
+  ...props
+}: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g id="Keyboard arrow down" clipPath="url(#clip0_150_6617)">
+        <path
+          id="Vector"
+          d="M7.41 8.58984L12 13.1698L16.59 8.58984L18 9.99984L12 15.9998L6 9.99984L7.41 8.58984Z"
+          fill="#ECECEC"
+        />
+      </g>
+      <defs>
+        <clipPath id="clip0_150_6617">
+          <rect width="24" height="24" fill="white" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}
+
+export default ArrowDownIcon;

--- a/src/components/common/Icon/Icons/index.tsx
+++ b/src/components/common/Icon/Icons/index.tsx
@@ -1,9 +1,11 @@
+import ArrowDownIcon from './ArrowDownIcon';
 import GoogleIcon from './GoogleIcon';
 import KakaoIcon from './KakaoIcon';
 
 const iconName = {
   kakao: KakaoIcon,
   google: GoogleIcon,
+  arrowDown: ArrowDownIcon,
 };
 
 export type IconNames = keyof typeof iconName;

--- a/src/components/signup/SignupForm/Select/index.stories.tsx
+++ b/src/components/signup/SignupForm/Select/index.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { ChangeEvent, useState } from 'react';
+
+import Select from '.';
+
+const meta: Meta<typeof Select> = {
+  component: Select,
+  argTypes: {
+    hasSideContent: {
+      option: [true, false],
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryFn<typeof Select>;
+
+export const Default: Story = args => {
+  const [value, setValue] = useState({ test: '' });
+  const onChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { name, value } = e.target;
+
+    setValue(prev => ({ ...prev, [name]: value }));
+  };
+
+  const TEST_OPTIONS = ['테스트1', '테스트2', '테스트3', '테스트4', '테스트5'];
+  const TEST_VALUES = ['test1', 'test2', 'test3', 'test4', 'test5'];
+
+  return (
+    <>
+      <Select
+        name="test"
+        labels={TEST_OPTIONS}
+        values={TEST_VALUES}
+        onChange={onChange}
+        placeholder="테스트 플레이스홀더"
+        hasSideContent={args.hasSideContent}
+      />
+      <p style={{ color: '#CACACA' }}>
+        선택된 항목은 {value.test || 'placeholder'}입니다.
+      </p>
+    </>
+  );
+};

--- a/src/components/signup/SignupForm/Select/index.tsx
+++ b/src/components/signup/SignupForm/Select/index.tsx
@@ -1,0 +1,38 @@
+import Icon from '@/components/common/Icon';
+
+import { SelectProps } from './type';
+import * as S from './style';
+
+const Select = ({
+  labels,
+  values,
+  placeholder,
+  hasSideContent = true,
+  ...props
+}: SelectProps) => {
+  return (
+    <S.SelectWrapper>
+      <S.Select {...props} defaultValue={placeholder || ''}>
+        {placeholder != null ? (
+          <S.Option value={placeholder} hidden disabled>
+            {placeholder}
+          </S.Option>
+        ) : null}
+
+        {labels.map((optionName, idx) => (
+          <S.Option key={optionName} value={values[idx]}>
+            {optionName}
+          </S.Option>
+        ))}
+      </S.Select>
+
+      {hasSideContent ? (
+        <S.SideContent>
+          <Icon iconName="arrowDown" />
+        </S.SideContent>
+      ) : null}
+    </S.SelectWrapper>
+  );
+};
+
+export default Select;

--- a/src/components/signup/SignupForm/Select/style.ts
+++ b/src/components/signup/SignupForm/Select/style.ts
@@ -1,0 +1,42 @@
+import { styled } from '@/styles/stitches.config';
+
+export const SelectWrapper = styled('div', {
+  position: 'relative',
+
+  width: '100%',
+});
+
+export const Select = styled('select', {
+  position: 'relative',
+
+  width: '100%',
+
+  padding: '16px',
+
+  borderRadius: '4px',
+  backgroundColor: '#5C5C5C',
+
+  color: '#CACACA',
+
+  '&::placeholder': {
+    color: '#CACACA',
+  },
+});
+
+export const Option = styled('option', {
+  backgroundColor: '#fff',
+
+  color: 'black',
+});
+
+export const SideContent = styled('div', {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+
+  position: 'absolute',
+  right: '12px',
+  top: '50%',
+
+  transform: 'translateY(-50%)',
+});

--- a/src/components/signup/SignupForm/Select/type.ts
+++ b/src/components/signup/SignupForm/Select/type.ts
@@ -1,0 +1,10 @@
+import { ComponentProps } from 'react';
+
+import { Select } from './style';
+
+export interface SelectProps extends ComponentProps<typeof Select> {
+  labels: string[];
+  values: string[];
+  error?: boolean;
+  hasSideContent?: boolean;
+}


### PR DESCRIPTION
## ✨ 구현한 내용

- Select 컴포넌트를 추가합니다.
- placeholder props를 통해 select의 종류를 표시합니다.
- labels props를 통해 드롭다운으로 표시할 목록을 배열로 넘겨받습니다.
- values props를 통해 각 <option />에 해당하는 value 값을 배열로 넘겨받습니다.
- hasSideComponent props를 통해 우측 ArrowDownIcon을 표시할 지 결정합니다.

## ❓ 특이사항

- `options`와 `values` 값 및 스타일에 대해서는 임시로 설정하였습니다.

## 🧾 테스트 방법

- 스토리북을 통해 테스트할 수 있습니다.  