### PR TITLE
[ADD] FormRow 컴포넌트 추가

### DIFF
--- a/src/components/signup/SignupForm/FormRow/index.stories.tsx
+++ b/src/components/signup/SignupForm/FormRow/index.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { ChangeEvent, useState } from 'react';
+
+import TextField from '../TextField';
+import Select from '../Select';
+
+import FormRow from '.';
+
+const meta: Meta<typeof FormRow> = {
+  component: FormRow,
+  argTypes: {
+    direction: {
+      options: ['column', 'row'],
+      control: { type: 'select' },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryFn<typeof FormRow>;
+
+export const WrapperWithTextField: Story = args => {
+  const [value, setValue] = useState({ test: '' });
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+
+    setValue(prev => ({ ...prev, [name]: value }));
+  };
+
+  return (
+    <FormRow {...args}>
+      <TextField
+        name="test"
+        value={value.test}
+        onChange={onChange}
+        placeholder="테스트"
+        error={value.test === ''}
+      />
+    </FormRow>
+  );
+};
+WrapperWithTextField.args = {
+  id: 'test',
+  label: '텍스트필드 테스트',
+  isRequired: false,
+  bottomText: '텍스트필드 테스트 바텀 텍스트',
+  errorMessage: '텍스트필드 테스트 문구를 입력해주세요',
+};
+
+export const WrapperWithSelect: Story = args => {
+  const [value, setValue] = useState({ test: '' });
+  const onChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { name, value } = e.target;
+
+    setValue(prev => ({ ...prev, [name]: value }));
+  };
+
+  const TEST_OPTIONS = ['테스트1', '테스트2', '테스트3', '테스트4', '테스트5'];
+  const TEST_VALUES = ['test1', 'test2', 'test3', 'test4', 'test5'];
+
+  return (
+    <FormRow {...args}>
+      <Select
+        name="test"
+        labels={TEST_OPTIONS}
+        values={TEST_VALUES}
+        error={value.test === ''}
+        onChange={onChange}
+        placeholder="테스트 플레이스홀더"
+      />
+    </FormRow>
+  );
+};
+WrapperWithSelect.args = {
+  id: 'test',
+  label: '셀렉트 테스트',
+  isRequired: false,
+  bottomText: '셀렉트 테스트 바텀 텍스트',
+  errorMessage: '셀렉트 테스트 문구를 선택해주세요',
+};
+
+export const WrapperWithMultiContents: Story = args => {
+  const [value, setValue] = useState({ test1: '', test2: '', test3: '' });
+  const onChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { name, value } = e.target;
+
+    setValue(prev => ({ ...prev, [name]: value }));
+  };
+
+  const TEST_OPTIONS = ['테스트1', '테스트2', '테스트3', '테스트4', '테스트5'];
+  const TEST_VALUES = ['test1', 'test2', 'test3', 'test4', 'test5'];
+
+  return (
+    <FormRow {...args}>
+      <Select
+        name="test1"
+        labels={TEST_OPTIONS}
+        values={TEST_VALUES}
+        error={value.test1 === ''}
+        onChange={onChange}
+        placeholder="테스트 플레이스홀더"
+      />
+      <Select
+        name="test2"
+        labels={TEST_OPTIONS}
+        values={TEST_VALUES}
+        error={value.test2 === ''}
+        onChange={onChange}
+        placeholder="테스트 플레이스홀더"
+      />
+      <Select
+        name="test3"
+        labels={TEST_OPTIONS}
+        values={TEST_VALUES}
+        error={value.test3 === ''}
+        onChange={onChange}
+        placeholder="테스트 플레이스홀더"
+      />
+    </FormRow>
+  );
+};
+WrapperWithMultiContents.args = {
+  id: 'test',
+  label: '멀티컨텐츠 테스트',
+  isRequired: false,
+  bottomText: '멀티컨텐츠 테스트 바텀 텍스트',
+  errorMessage: '멀티컨텐츠 테스트 문구를 선택해주세요',
+};

--- a/src/components/signup/SignupForm/FormRow/index.tsx
+++ b/src/components/signup/SignupForm/FormRow/index.tsx
@@ -1,0 +1,40 @@
+import { Children, ReactElement } from 'react';
+
+import Text from '@/components/common/Text';
+
+import * as S from './style';
+import { FormRowProps } from './type';
+
+const FormRow = ({
+  id,
+  label,
+  isRequired = false,
+  children,
+  bottomText,
+  errorMessage,
+  direction = 'column',
+  ...props
+}: FormRowProps) => {
+  const isError = Children.toArray(children).some(
+    child => (child as ReactElement).props.error,
+  );
+
+  return (
+    <S.FormRow {...props}>
+      <S.Label htmlFor={id}>
+        <Text isRequired={isRequired}>{label}</Text>
+      </S.Label>
+      <S.Container>
+        <S.Content direction={direction}>{children}</S.Content>
+        <S.BottomTextWrapper>
+          {bottomText != null ? (
+            <S.BottomText>{bottomText}</S.BottomText>
+          ) : null}
+          {isError ? <S.ErrorMessage>{errorMessage}</S.ErrorMessage> : null}
+        </S.BottomTextWrapper>
+      </S.Container>
+    </S.FormRow>
+  );
+};
+
+export default FormRow;

--- a/src/components/signup/SignupForm/FormRow/style.ts
+++ b/src/components/signup/SignupForm/FormRow/style.ts
@@ -1,0 +1,85 @@
+import { styled } from '@/styles/stitches.config';
+
+export const FormRow = styled('div', {
+  display: 'grid',
+  gridTemplateColumns: '1fr 5fr',
+  alignItems: 'center',
+
+  position: 'relative',
+
+  width: '100%',
+
+  '&:not(:last-of-type)::after': {
+    content: '',
+    position: 'absolute',
+    bottom: '-20px',
+
+    width: '100%',
+    height: '1px',
+
+    backgroundColor: '#5C5C5C',
+  },
+});
+
+export const Label = styled('label', {});
+
+export const Container = styled('div', {
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'flex-start',
+  alignItems: 'center',
+  gap: '8px',
+});
+
+export const Content = styled('div', {
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '8px',
+
+  width: '100%',
+
+  variants: {
+    direction: {
+      column: {},
+      row: {
+        flexDirection: 'row',
+        justifyContent: 'center',
+        alignItems: 'center',
+      },
+    },
+  },
+});
+
+export const BottomTextWrapper = styled('div', {
+  display: 'flex',
+  justifyContent: 'flex-start',
+  alignItems: 'center',
+  gap: '8px',
+
+  width: '100%',
+});
+
+export const BottomText = styled('span', {
+  fontSize: '14px',
+  fontStyle: 'normal',
+  fontWeight: 400,
+  lineHeight: '16px',
+  letterSpacing: '0.16px',
+
+  color: '#CACACA',
+});
+
+export const ErrorMessage = styled('span', {
+  fontVariantNumeric: 'lining-nums proportional-nums',
+  fontFeatureSettings: 'dlig on',
+  fontFamily: 'Pretendard Variable',
+  fontSize: '14px',
+  fontStyle: 'normal',
+  fontWeight: 400,
+  lineHheight: '14px',
+  letterSpacing: '0.2px',
+
+  color: '#E84B4B',
+});

--- a/src/components/signup/SignupForm/FormRow/type.ts
+++ b/src/components/signup/SignupForm/FormRow/type.ts
@@ -2,7 +2,7 @@ import { ComponentProps, ReactNode } from 'react';
 
 import { FormRow } from './style';
 
-export interface InputWrapperProps extends ComponentProps<typeof FormRow> {
+export interface FormRowProps extends ComponentProps<typeof FormRow> {
   id: string;
   label?: ReactNode;
   isRequired?: boolean;

--- a/src/components/signup/SignupForm/FormRow/type.ts
+++ b/src/components/signup/SignupForm/FormRow/type.ts
@@ -1,0 +1,12 @@
+import { ComponentProps, ReactNode } from 'react';
+
+import { FormRow } from './style';
+
+export interface InputWrapperProps extends ComponentProps<typeof FormRow> {
+  id: string;
+  label?: ReactNode;
+  isRequired?: boolean;
+  bottomText?: string;
+  errorMessage?: string;
+  direction?: 'column' | 'row';
+}


### PR DESCRIPTION
## ✨ 구현한 내용
- Form 컴포넌트 내에서 각 항목을 관리하는 FormRow 컴포넌트를 추가합니다.
- 자식 컴포넌트의 error props를 확인하고 error === true라면 에러 메시지를 표시합니다.
- direction props를 통해 자식 컴포넌트를 나열하는 방향을 결정합니다.
- bottomText props가 존재한다면 표시합니다.

## 🧾 테스트 방법
- 스토리북을 통해 테스트할 수 있습니다.