### PR TITLE
[ADD] Signup Page 추가

### DIFF
--- a/src/components/signup/SignupView/index.stories.tsx
+++ b/src/components/signup/SignupView/index.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import SignupView from '.';
+
+const meta: Meta<typeof SignupView> = {
+  component: SignupView,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SignupView>;
+
+export const Default: Story = {};

--- a/src/components/signup/SignupView/index.tsx
+++ b/src/components/signup/SignupView/index.tsx
@@ -1,0 +1,176 @@
+import { ChangeEvent, FormEvent, useState } from 'react';
+
+import Button from '@/components/common/Button';
+import Text from '@/components/common/Text';
+import { DATES, MONTHS, YEARS } from '@/constants/birthDates';
+import FormRow from '@/components/signup/SignupForm/FormRow';
+import TextField from '@/components/signup/SignupForm/TextField';
+import Select from '@/components/signup/SignupForm/Select';
+
+import * as S from './style';
+
+const INITIAL_SINGUP_DATA = {
+  nickname: '',
+  'birth-y': '',
+  'birth-m': '',
+  'birth-d': '',
+  gender: '',
+  height: '',
+  weight: '',
+  'sbd-s': '',
+  'sbd-b': '',
+  'sbd-d': '',
+};
+
+export default function SignupView() {
+  const [signupData, setSignupData] =
+    useState<typeof INITIAL_SINGUP_DATA>(INITIAL_SINGUP_DATA);
+
+  const onChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+
+    setSignupData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const onSubmitSignupData = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    // api call with signupData
+  };
+
+  return (
+    <S.Layout>
+      <S.Wrapper>
+        <S.HeaderWrapper>
+          <S.Title>회원정보를 입력해주세요</S.Title>
+          <Text isRequired>필수 입력사항</Text>
+        </S.HeaderWrapper>
+        <S.SignupForm id="signupForm" onSubmit={onSubmitSignupData}>
+          <FormRow
+            id="nickname"
+            label="닉네임"
+            isRequired
+            bottomText="*8자 이내"
+            errorMessage="닉네임을 입력해주세요"
+          >
+            <TextField
+              name="nickname"
+              value={signupData.nickname}
+              onChange={onChange}
+              placeholder="닉네임"
+              error={signupData.nickname === ''}
+              sideContent={<Button>중복 확인</Button>}
+            />
+          </FormRow>
+          <FormRow
+            id="birth"
+            label="생년월일"
+            isRequired
+            errorMessage="생년월일을 입력해주세요"
+            direction="row"
+          >
+            <Select
+              id="birth"
+              name="birth-y"
+              labels={YEARS.map(year => year + '년')}
+              values={YEARS}
+              onChange={onChange}
+              error={signupData['birth-y'] === ''}
+              placeholder="년도"
+            />
+            <Select
+              name="birth-m"
+              labels={MONTHS.map(month => month + '월')}
+              values={MONTHS}
+              onChange={onChange}
+              error={signupData['birth-m'] === ''}
+              placeholder="월"
+            />
+            <Select
+              name="birth-d"
+              labels={DATES.map(date => date + '일')}
+              values={DATES}
+              onChange={onChange}
+              error={signupData['birth-d'] === ''}
+              placeholder="일"
+            />
+          </FormRow>
+          <FormRow
+            id="gender"
+            label="성별"
+            isRequired
+            errorMessage="성별을 선택해주세요"
+          >
+            <Select
+              name="gender"
+              labels={['남성', '여성', '기타']}
+              values={['M', 'F', 'X']}
+              error={signupData.gender === ''}
+              onChange={onChange}
+              placeholder="성별"
+              hasSideContent={true}
+            />
+          </FormRow>
+          <FormRow
+            id="height"
+            label="키"
+            isRequired
+            errorMessage="키를 입력해주세요"
+          >
+            <TextField
+              name="height"
+              type="number"
+              value={signupData.height}
+              onChange={onChange}
+              placeholder="키"
+              sideContent={<S.UnitText>kg</S.UnitText>}
+              error={signupData.height === ''}
+            />
+          </FormRow>
+          <FormRow
+            id="weight"
+            label="몸무게"
+            isRequired
+            errorMessage="몸무게를 입력해주세요"
+          >
+            <TextField
+              name="weight"
+              type="number"
+              value={signupData.weight}
+              onChange={onChange}
+              placeholder="몸무게"
+              sideContent={<S.UnitText>cm</S.UnitText>}
+              error={signupData.weight === ''}
+            />
+          </FormRow>
+          <FormRow id="sbd" label="3대 측정">
+            <TextField
+              name="sbd-s"
+              value={signupData['sbd-s']}
+              onChange={onChange}
+              placeholder="스쿼트"
+              sideContent={<S.UnitText>kg</S.UnitText>}
+            />
+            <TextField
+              name="sbd-b"
+              value={signupData['sbd-b']}
+              onChange={onChange}
+              placeholder="벤치프레스"
+              sideContent={<S.UnitText>kg</S.UnitText>}
+            />
+            <TextField
+              name="sbd-d"
+              value={signupData['sbd-d']}
+              onChange={onChange}
+              placeholder="데드리프트"
+              sideContent={<S.UnitText>kg</S.UnitText>}
+            />
+          </FormRow>
+        </S.SignupForm>
+        <Button size="large" color="primary" type="submit" form="signupForm">
+          가입 완료
+        </Button>
+      </S.Wrapper>
+    </S.Layout>
+  );
+}

--- a/src/components/signup/SignupView/style.ts
+++ b/src/components/signup/SignupView/style.ts
@@ -1,0 +1,85 @@
+import { styled } from '@/styles/stitches.config';
+
+export const Layout = styled('main', {
+  display: 'inline-flex',
+  flexDirection: 'column',
+  justifyContent: 'flex-start',
+  alignItems: 'flex-start',
+
+  width: '100%',
+  minHeight: '100dvh',
+
+  margin: '0 auto',
+
+  backgroundColor: '#323232',
+
+  fontFamily: '$notoSansKr',
+});
+
+export const Wrapper = styled('section', {
+  margin: '0 auto',
+
+  maxWidth: '931px',
+  minWidth: '736px',
+  width: '100%',
+  height: '100%',
+});
+
+export const HeaderWrapper = styled('div', {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'flex-end',
+
+  margin: '0 0 14px',
+});
+
+export const Title = styled('h1', {
+  fontSize: '32px',
+  fontStyle: 'normal',
+  fontWeight: 500,
+  letterSpacing: '0.32px',
+  textAlign: 'left',
+
+  color: '#FFFFFF',
+});
+
+export const SignupForm = styled('form', {
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '40px',
+
+  width: '100%',
+
+  padding: '40px',
+  margin: '0 0 24px',
+
+  borderRadius: 4,
+
+  backgroundColor: '#414141',
+});
+
+export const GridColumns = styled('div', {});
+
+export const SideContent = styled('div', {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+
+  position: 'absolute',
+  right: '12px',
+  top: '50%',
+
+  transform: 'translateY(-50%)',
+});
+
+export const UnitText = styled('span', {
+  fontSize: '16px',
+  fontStyle: 'normal',
+  fontWeight: 500,
+  lineHeight: '16px',
+  letterSpacing: '0.18px',
+
+  color: '#CACACA',
+});

--- a/src/constants/birthDates.ts
+++ b/src/constants/birthDates.ts
@@ -1,0 +1,8 @@
+export const YEARS = Array.from(
+  { length: 100 },
+  (_, idx) => `${new Date().getFullYear() - idx}`,
+);
+
+export const MONTHS = Array.from({ length: 12 }, (_, idx) => `${idx + 1}`);
+
+export const DATES = Array.from({ length: 31 }, (_, idx) => `${idx + 1}`);

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,3 +1,5 @@
+import SignupView from '@/components/signup/SignupView';
+
 export default function Signup() {
-  return <div>signup 입니다</div>;
+  return <SignupView />;
 }


### PR DESCRIPTION
## ✨ 구현한 내용

- signup page를 추가합니다.
- signupData의 property는 임시로 설정하였습니다.
- onSubmit 시 서버로 데이터를 전송하는 api가 부재하므로 주석으로 표시해두었습니다.
- Button의 디자인이 완료되지 않았기 때문에 임시 디자인을 사용하였습니다.
- 추후 공통 레이아웃 컴포넌트를 생성한다면, SignupView에서 사용한 Layout 컴포넌트를 제거할 예정입니다.

## 🧾 테스트 방법

- 스토리북을 통해 테스트할 수 있습니다.